### PR TITLE
Refactor event count API to work natively with querysets.

### DIFF
--- a/bec_alerts/tests/test_models.py
+++ b/bec_alerts/tests/test_models.py
@@ -5,12 +5,12 @@ from datetime import date
 
 import pytest
 
-from bec_alerts.models import IssueBucket
+from bec_alerts.models import Issue
 from bec_alerts.tests import IssueFactory
 
 
 @pytest.mark.django_db
-def test_issuebucket_event_count_uniques():
+def test_issue_with_event_counts_uniques():
     issue = IssueFactory.create()
 
     issue.count_event('asdf', date(2018, 1, 1))
@@ -18,11 +18,13 @@ def test_issuebucket_event_count_uniques():
     issue.count_event('asdf', date(2018, 1, 2))
     issue.count_event('asdf', date(2018, 1, 3))
     issue.count_event('qwer', date(2018, 1, 1))
-    assert IssueBucket.objects.event_count(issue=issue) == 2
+
+    issue = Issue.objects.with_event_counts().get(pk=issue.pk)
+    assert issue.event_count == 2
 
 
 @pytest.mark.django_db
-def test_issuebucket_event_count_date_ranges():
+def test_issue_with_event_counts_date_ranges():
     issue = IssueFactory.create()
 
     issue.count_event('day1-1', date(2018, 1, 1))
@@ -31,12 +33,32 @@ def test_issuebucket_event_count_date_ranges():
     issue.count_event('day3-1', date(2018, 1, 3))
     issue.count_event('day3-2', date(2018, 1, 3))
 
-    assert IssueBucket.objects.event_count(start_date=date(2018, 1, 1)) == 5
-    assert IssueBucket.objects.event_count(start_date=date(2018, 1, 1), end_date=date(2018, 1, 2)) == 3
-    assert IssueBucket.objects.event_count(start_date=date(2018, 1, 2), end_date=date(2018, 1, 2)) == 1
-    assert IssueBucket.objects.event_count(end_date=date(2018, 1, 2)) == 3
-    assert IssueBucket.objects.event_count(start_date=date(2018, 1, 1), end_date=date(2018, 1, 3)) == 5
-    assert IssueBucket.objects.event_count(start_date=date(2018, 1, 6)) == 0
+    assert Issue.objects.filter_dates(
+        start_date=date(2018, 1, 1),
+    ).event_count() == 5
+
+    assert Issue.objects.filter_dates(
+        start_date=date(2018, 1, 1),
+        end_date=date(2018, 1, 2),
+    ).event_count() == 3
+
+    assert Issue.objects.filter_dates(
+        start_date=date(2018, 1, 2),
+        end_date=date(2018, 1, 2),
+    ).event_count() == 1
+
+    assert Issue.objects.filter_dates(
+        end_date=date(2018, 1, 2),
+    ).event_count() == 3
+
+    assert Issue.objects.filter_dates(
+        start_date=date(2018, 1, 1),
+        end_date=date(2018, 1, 3),
+    ).event_count() == 5
+
+    assert Issue.objects.filter_dates(
+        start_date=date(2018, 1, 6),
+    ).event_count() == 0
 
 
 @pytest.mark.django_db
@@ -47,28 +69,5 @@ def test_issuebucket_event_count_multiple_issues():
     issue1.count_event('qwer', date(2018, 1, 1))
     issue2.count_event('asdf', date(2018, 1, 2))
 
-    assert IssueBucket.objects.event_count(issue=issue1) == 2
-    assert IssueBucket.objects.event_count(issue=issue2) == 1
-
-
-@pytest.mark.django_db
-def test_issuebucket_top_issue_counts():
-    issue1, issue2, issue3 = IssueFactory.create_batch(3)
-
-    for k in range(10):
-        issue1.count_event(str(k), date(2018, 1, 1))
-    for k in range(20):
-        issue2.count_event(str(k), date(2018, 1, 1))
-    for k in range(5):
-        issue3.count_event(str(k), date(2018, 1, 1))
-
-    assert IssueBucket.objects.top_issue_counts(limit=3) == [
-        (20, issue2),
-        (10, issue1),
-        (5, issue3),
-    ]
-
-    assert IssueBucket.objects.top_issue_counts(limit=2) == [
-        (20, issue2),
-        (10, issue1),
-    ]
+    assert Issue.objects.filter(pk=issue1.pk).event_count() == 2
+    assert Issue.objects.filter(pk=issue2.pk).event_count() == 1


### PR DESCRIPTION
This will make it easier in a future PR to update the top-crashers rule to ignore errors from webextensions by filtering issues in the top-10 list.