### PR TITLE
Ignore extension errors in top crashers trigger.

### DIFF
--- a/bec_alerts/triggers.py
+++ b/bec_alerts/triggers.py
@@ -169,6 +169,7 @@ class NewTopIssueTrigger(Trigger):
         week_ago = now - timedelta(days=7)
         return (
             Issue.objects
+            .exclude(module__startswith='moz-extension')
             .filter_dates(start_date=week_ago.date())
             .with_event_counts()
             .order_by('-event_count')[:10]


### PR DESCRIPTION
Well, that was simpler than I thought after landing the refactor.

I tested this locally by simulating an error a bunch of times:

```sh
$ docker-compose run processor bec-alerts simulate_error --message=fakemozextension --no-traceback
```

Then I ran the watcher in dry-run mode:

```sh
$ docker-compose run processor bec-alerts watcher --once --console-alerts --dry-run
Starting bec-alerts_localstack_1         ... done
Starting bec-alerts_processor-postgres_1 ... done
MainProcess | INFO | --dry-run passed; no run logs will be saved.
MainProcess | INFO | Found 2 issues since last finished run.
MainProcess | DEBUG | Evaluting HealthCheckTrigger against issue 1.
MainProcess | DEBUG | Evaluting HealthCheckTrigger against issue 2.
MainProcess | DEBUG | Evaluting NewTopIssueTrigger against issue 1.
MainProcess | DEBUG | Evaluting NewTopIssueTrigger against issue 2.
MainProcess | INFO | Trigger NewTopIssueTrigger alerting user mkelly@mozilla.com of issue 2
== Sending Alert
   To: mkelly@mozilla.com
   Subject: [Firefox Browser Errors] New top crasher: Exception: fakemozextension

   New alert from Firefox Browser Error trigger: New top crasher

   Exception: fakemozextension

   This issue can be viewed in Sentry:

   https://sentry.prod.mozaws.net/operations/nightly-js-errors/issues/2/
```

Then, I manually edited it in the database to have `moz-extension://foo/bar/baz.jsm` as the module, and manually modified the event minimum in the top crashers trigger to be 2, and ran the watcher again:

```sh
$ docker-compose run processor bec-alerts watcher --once --console-alerts --dry-run
Starting bec-alerts_localstack_1         ... done
Starting bec-alerts_processor-postgres_1 ... done
MainProcess | INFO | --dry-run passed; no run logs will be saved.
MainProcess | INFO | Found 2 issues since last finished run.
MainProcess | DEBUG | Evaluting HealthCheckTrigger against issue 1.
MainProcess | DEBUG | Evaluting HealthCheckTrigger against issue 2.
MainProcess | DEBUG | Evaluting NewTopIssueTrigger against issue 1.
MainProcess | DEBUG | Evaluting NewTopIssueTrigger against issue 2.
```

The database exposes itself on port 8574 if you want to replicate those steps yourself, or you could just trust me. It's a small change.